### PR TITLE
fix: improve error handling for storage authentication failures

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -377,15 +377,31 @@ class Component(ComponentBase):
     @staticmethod
     def write_batch(table_or_uri, data, mode, storage_options, writer_properties, partition_by=None, schema_mode=None):
         start = time.time()
-        write_deltalake(
-            table_or_uri=table_or_uri,
-            data=data,
-            mode=mode,
-            storage_options=storage_options,
-            writer_properties=writer_properties,
-            partition_by=partition_by,
-            schema_mode=schema_mode,
-        )
+        try:
+            write_deltalake(
+                table_or_uri=table_or_uri,
+                data=data,
+                mode=mode,
+                storage_options=storage_options,
+                writer_properties=writer_properties,
+                partition_by=partition_by,
+                schema_mode=schema_mode,
+            )
+        except OSError as e:
+            error_msg = str(e)
+            # Detect common authentication failures and provide actionable messages
+            if "NoAuthenticationInformation" in error_msg or "401" in error_msg:
+                raise UserException(
+                    f"Storage authentication failed. Please verify your credentials are valid and not expired. "
+                    f"Target: {table_or_uri}"
+                ) from e
+            if "403" in error_msg or "Forbidden" in error_msg:
+                raise UserException(
+                    f"Storage access denied. Please verify your credentials have the required permissions. "
+                    f"Target: {table_or_uri}"
+                ) from e
+            # Re-raise other OSErrors with context
+            raise UserException(f"Failed to write to Delta Lake: {error_msg}") from e
         logging.info(f"Batch written in {time.time() - start:.2f}s")
 
     def init_connection(self) -> DuckDBPyConnection:

--- a/src/component.py
+++ b/src/component.py
@@ -304,8 +304,39 @@ class Component(ComponentBase):
             "max_retries": "2",
         }
 
+        # Unity Catalog access method takes precedence over provider setting
+        # This handles cases where provider might be set from previous config but access_method is unity_catalog
+        if self.params.access_method == "unity_catalog":
+            self._uc_client = WorkspaceClient(
+                host=self.params.unity_catalog_url, token=self.params.unity_catalog_token
+            )
+
+            temp_creds, region = self._get_temp_credentials_and_region()
+            uri = temp_creds.url
+
+            if temp_creds.azure_user_delegation_sas:
+                storage_options |= {
+                    "azure_storage_account_name": temp_creds.url.split("@")[1].split(".")[0],
+                    "azure_storage_sas_token": temp_creds.azure_user_delegation_sas.sas_token,
+                }
+            elif temp_creds.aws_temp_credentials:
+                storage_options |= {
+                    "aws_region": region,
+                    "aws_access_key_id": temp_creds.aws_temp_credentials.access_key_id,
+                    "aws_secret_access_key": temp_creds.aws_temp_credentials.secret_access_key,
+                    "aws_session_token": temp_creds.aws_temp_credentials.session_token,
+                }
+
+            return storage_options, uri
+
+        # Direct storage access - validate credentials before use
         match self.params.provider:
             case "abs":
+                if not self.params.abs_account_name or not self.params.abs_sas_token:
+                    raise UserException(
+                        "Azure Blob Storage credentials are missing. "
+                        "Please provide both 'Storage Account Name' and 'SAS token' for direct storage access."
+                    )
                 uri = f"az://{self.params.destination.container_name}/{self.params.destination.blob_name}"
                 storage_options |= {
                     "azure_storage_account_name": self.params.abs_account_name,
@@ -313,6 +344,11 @@ class Component(ComponentBase):
                 }
 
             case "s3":
+                if not self.params.aws_region or not self.params.aws_key_id or not self.params.aws_key_secret:
+                    raise UserException(
+                        "AWS S3 credentials are missing. Please provide 'AWS Region', 'Access key ID', "
+                        "and 'Secret Access Key' for direct storage access."
+                    )
                 uri = f"s3://{self.params.destination.container_name}/{self.params.destination.blob_name}"
                 storage_options |= {
                     "aws_region": self.params.aws_region,
@@ -321,32 +357,20 @@ class Component(ComponentBase):
                 }
 
             case "gcs":
+                if not self.params.gcp_service_account_key:
+                    raise UserException(
+                        "Google Cloud Storage credentials are missing. "
+                        "Please provide 'Service Account Key' for direct storage access."
+                    )
                 uri = f"gs://{self.params.destination.container_name}/{self.params.destination.blob_name}"
                 storage_options |= {"google_service_account_key": self.params.gcp_service_account_key}
 
             case _:
-                if not self.params.access_method == "unity_catalog":
-                    raise UserException(f"Unknown provider: {self.params.provider}")
-
-                self._uc_client = WorkspaceClient(
-                    host=self.params.unity_catalog_url, token=self.params.unity_catalog_token
+                raise UserException(
+                    f"Unknown or missing storage provider: '{self.params.provider}'. "
+                    "Please select a valid cloud storage provider "
+                    "(AWS S3, Azure Blob Storage, or Google Cloud Storage) or use Unity Catalog access method."
                 )
-
-                temp_creds, region = self._get_temp_credentials_and_region()
-                uri = temp_creds.url
-
-                if temp_creds.azure_user_delegation_sas:
-                    storage_options |= {
-                        "azure_storage_account_name": temp_creds.url.split("@")[1].split(".")[0],
-                        "azure_storage_sas_token": temp_creds.azure_user_delegation_sas.sas_token,
-                    }
-                elif temp_creds.aws_temp_credentials:
-                    storage_options |= {
-                        "aws_region": region,
-                        "aws_access_key_id": temp_creds.aws_temp_credentials.access_key_id,
-                        "aws_secret_access_key": temp_creds.aws_temp_credentials.secret_access_key,
-                        "aws_session_token": temp_creds.aws_temp_credentials.session_token,
-                    }
 
         return storage_options, uri
 

--- a/src/component.py
+++ b/src/component.py
@@ -304,39 +304,8 @@ class Component(ComponentBase):
             "max_retries": "2",
         }
 
-        # Unity Catalog access method takes precedence over provider setting
-        # This handles cases where provider might be set from previous config but access_method is unity_catalog
-        if self.params.access_method == "unity_catalog":
-            self._uc_client = WorkspaceClient(
-                host=self.params.unity_catalog_url, token=self.params.unity_catalog_token
-            )
-
-            temp_creds, region = self._get_temp_credentials_and_region()
-            uri = temp_creds.url
-
-            if temp_creds.azure_user_delegation_sas:
-                storage_options |= {
-                    "azure_storage_account_name": temp_creds.url.split("@")[1].split(".")[0],
-                    "azure_storage_sas_token": temp_creds.azure_user_delegation_sas.sas_token,
-                }
-            elif temp_creds.aws_temp_credentials:
-                storage_options |= {
-                    "aws_region": region,
-                    "aws_access_key_id": temp_creds.aws_temp_credentials.access_key_id,
-                    "aws_secret_access_key": temp_creds.aws_temp_credentials.secret_access_key,
-                    "aws_session_token": temp_creds.aws_temp_credentials.session_token,
-                }
-
-            return storage_options, uri
-
-        # Direct storage access - validate credentials before use
         match self.params.provider:
             case "abs":
-                if not self.params.abs_account_name or not self.params.abs_sas_token:
-                    raise UserException(
-                        "Azure Blob Storage credentials are missing. "
-                        "Please provide both 'Storage Account Name' and 'SAS token' for direct storage access."
-                    )
                 uri = f"az://{self.params.destination.container_name}/{self.params.destination.blob_name}"
                 storage_options |= {
                     "azure_storage_account_name": self.params.abs_account_name,
@@ -344,11 +313,6 @@ class Component(ComponentBase):
                 }
 
             case "s3":
-                if not self.params.aws_region or not self.params.aws_key_id or not self.params.aws_key_secret:
-                    raise UserException(
-                        "AWS S3 credentials are missing. Please provide 'AWS Region', 'Access key ID', "
-                        "and 'Secret Access Key' for direct storage access."
-                    )
                 uri = f"s3://{self.params.destination.container_name}/{self.params.destination.blob_name}"
                 storage_options |= {
                     "aws_region": self.params.aws_region,
@@ -357,20 +321,32 @@ class Component(ComponentBase):
                 }
 
             case "gcs":
-                if not self.params.gcp_service_account_key:
-                    raise UserException(
-                        "Google Cloud Storage credentials are missing. "
-                        "Please provide 'Service Account Key' for direct storage access."
-                    )
                 uri = f"gs://{self.params.destination.container_name}/{self.params.destination.blob_name}"
                 storage_options |= {"google_service_account_key": self.params.gcp_service_account_key}
 
             case _:
-                raise UserException(
-                    f"Unknown or missing storage provider: '{self.params.provider}'. "
-                    "Please select a valid cloud storage provider "
-                    "(AWS S3, Azure Blob Storage, or Google Cloud Storage) or use Unity Catalog access method."
+                if not self.params.access_method == "unity_catalog":
+                    raise UserException(f"Unknown provider: {self.params.provider}")
+
+                self._uc_client = WorkspaceClient(
+                    host=self.params.unity_catalog_url, token=self.params.unity_catalog_token
                 )
+
+                temp_creds, region = self._get_temp_credentials_and_region()
+                uri = temp_creds.url
+
+                if temp_creds.azure_user_delegation_sas:
+                    storage_options |= {
+                        "azure_storage_account_name": temp_creds.url.split("@")[1].split(".")[0],
+                        "azure_storage_sas_token": temp_creds.azure_user_delegation_sas.sas_token,
+                    }
+                elif temp_creds.aws_temp_credentials:
+                    storage_options |= {
+                        "aws_region": region,
+                        "aws_access_key_id": temp_creds.aws_temp_credentials.access_key_id,
+                        "aws_secret_access_key": temp_creds.aws_temp_credentials.secret_access_key,
+                        "aws_session_token": temp_creds.aws_temp_credentials.session_token,
+                    }
 
         return storage_options, uri
 


### PR DESCRIPTION
## Summary

This PR improves error handling in the Delta Lake Writer component to convert storage authentication failures from internal errors into user-friendly `UserException` messages. This was triggered by a Datadog alert where an invalid/expired Azure SAS token caused an `OSError` that surfaced as an internal error instead of a user error.

**Change:**
- **Wrap `write_deltalake()` in try/except**: Catch `OSError` from delta-rs and convert to `UserException` with actionable messages for common auth failures (401/NoAuthenticationInformation, 403/Forbidden).

## Updates since last revision

Per user feedback, reverted the config parameter logic changes (access_method precedence and credential validation) since not all test environments are available to test those changes. This PR now contains only the error handling improvement.

## Review & Testing Checklist for Human

- [ ] **Review OSError catch scope**: All OSErrors from `write_deltalake()` are now converted to `UserException`. Verify this doesn't mask legitimate internal errors that should be reported differently.
- [ ] **Test with invalid credentials**: Confirm that invalid/expired SAS tokens now produce a `UserException` with the message "Storage authentication failed..." instead of an internal error.
- [ ] **Test with valid credentials**: Confirm normal write operations still work correctly.

**Recommended test plan:**
1. Run a job with valid Azure credentials → should succeed
2. Run a job with an invalid/expired SAS token → should fail with UserException, not internal error

### Notes

- The original incident was caused by an invalid SAS token (user confirmed config was correct: `direct_storage` + `abs`)
- The substring matching for error detection ("401", "403", "NoAuthenticationInformation") is somewhat fragile but covers the observed error patterns
- No unit tests added for the new error handling logic

Link to Devin run: https://app.devin.ai/sessions/0263e46115d045da8602a6ee5920a1a9
Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)