### PR TITLE
[CFTL-719] Support Azure stacks: service-principal auth + Azure Blob input staging

### DIFF
--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -32,14 +32,60 @@
         }
       }
     },
+    "auth_type": {
+      "enum": [
+        "pat",
+        "service_principal"
+      ],
+      "type": "string",
+      "title": "Authentication Type",
+      "default": "pat",
+      "options": {
+        "enum_titles": [
+          "Personal Access Token",
+          "Service Principal (OAuth M2M)"
+        ],
+        "dependencies": {
+          "access_method": "unity_catalog"
+        }
+      },
+      "description": "Choose how to authenticate to Unity Catalog.",
+      "propertyOrder": 3
+    },
     "#unity_catalog_token": {
       "type": "string",
       "title": "PAT token",
       "format": "password",
-      "propertyOrder": 3,
+      "propertyOrder": 4,
       "options": {
         "dependencies": {
-          "access_method": "unity_catalog"
+          "access_method": "unity_catalog",
+          "auth_type": "pat"
+        }
+      }
+    },
+    "unity_catalog_client_id": {
+      "type": "string",
+      "title": "Client ID",
+      "description": "The service principal's Application (client) ID.",
+      "propertyOrder": 5,
+      "options": {
+        "dependencies": {
+          "access_method": "unity_catalog",
+          "auth_type": "service_principal"
+        }
+      }
+    },
+    "#unity_catalog_client_secret": {
+      "type": "string",
+      "title": "Client Secret",
+      "format": "password",
+      "description": "The service principal's OAuth secret.",
+      "propertyOrder": 6,
+      "options": {
+        "dependencies": {
+          "access_method": "unity_catalog",
+          "auth_type": "service_principal"
         }
       }
     },
@@ -64,12 +110,12 @@
       },
       "required": true,
       "description": "Select the cloud storage provider.",
-      "propertyOrder": 4
+      "propertyOrder": 7
     },
     "abs_account_name": {
       "type": "string",
       "title": "Storage Account Name",
-      "propertyOrder": 5,
+      "propertyOrder": 8,
       "options": {
         "dependencies": {
           "provider": "abs"
@@ -80,7 +126,7 @@
       "type": "string",
       "title": "SAS token",
       "format": "password",
-      "propertyOrder": 6,
+      "propertyOrder": 9,
       "options": {
         "dependencies": {
           "provider": "abs"
@@ -91,7 +137,7 @@
       "type": "string",
       "title": "AWS Region",
       "description": "The AWS region where the bucket is located for example 'eu-central-1' or 'us-east-1'.",
-      "propertyOrder": 7,
+      "propertyOrder": 10,
       "options": {
         "dependencies": {
           "provider": "s3"
@@ -101,7 +147,7 @@
     "aws_key_id": {
       "type": "string",
       "title": "Access key ID",
-      "propertyOrder": 8,
+      "propertyOrder": 11,
       "options": {
         "dependencies": {
           "provider": "s3"
@@ -112,7 +158,7 @@
       "type": "string",
       "title": "Secret Access Key",
       "format": "password",
-      "propertyOrder": 9,
+      "propertyOrder": 12,
       "options": {
         "dependencies": {
           "provider": "s3"
@@ -124,7 +170,7 @@
       "title": "Service Account Key",
       "description": "Copy & paste the whole JSON of the Google service account key file. For instructions on how to create the service account, see the <a href=\"https://help.keboola.com/components/writers/database/bigquery/#create-service-account\"> documentation.</a>",
       "format": "password",
-      "propertyOrder": 10,
+      "propertyOrder": 13,
       "options": {
         "dependencies": {
           "provider": "gcs"

--- a/src/component.py
+++ b/src/component.py
@@ -83,11 +83,11 @@ class Component(ComponentBase):
         relation = None
         if tables:
             dtypes = {key: value.data_types.get("base").dtype for key, value in self.table.schema.items()}
-            s3_files = self.get_s3_paths()
+            staging_files = self.get_staging_files()
 
             relation = self._connection.sql(f"""
             SELECT *
-            FROM read_csv({s3_files}, column_names={self.table.column_names}, dtypes={dtypes})
+            FROM read_csv({staging_files}, column_names={self.table.column_names}, dtypes={dtypes})
             """)
         if files:
             files_paths = [file.full_path for file in files]
@@ -161,9 +161,14 @@ class Component(ComponentBase):
         self._execute_query(f"DROP TABLE IF EXISTS {self.stg_name};")
 
     def _build_query_load_stage(self):
-        s3_files = self.get_s3_paths()
-        dirname = os.path.dirname(s3_files[0])
-        filenames = [os.path.basename(f) for f in s3_files]
+        files = self.get_staging_files()
+        if self.table.abs_staging:
+            return self._build_abs_load_stage(files)
+        return self._build_s3_load_stage(files)
+
+    def _build_s3_load_stage(self, files):
+        dirname = os.path.dirname(files[0])
+        filenames = [os.path.basename(f) for f in files]
         quoted_filenames = [f"'{file}'" for file in filenames]
         files_str = ", ".join(quoted_filenames)
 
@@ -173,6 +178,36 @@ class Component(ComponentBase):
           CREDENTIAL (AWS_ACCESS_KEY = '{self.table.s3_staging.credentials_access_key_id}',
                       AWS_SECRET_KEY = '{self.table.s3_staging.credentials_secret_access_key}',
                       AWS_SESSION_TOKEN = '{self.table.s3_staging.credentials_session_token}')
+        )
+        FILEFORMAT = CSV
+        FILES = ({files_str})
+        FORMAT_OPTIONS (
+          'header' = 'false',
+          'inferSchema' = 'false',
+          'mergeSchema' = 'false'
+        );
+        """
+        return load_query
+
+    def _build_abs_load_stage(self, files):
+        abs_stg = self.table.abs_staging
+        account_name, sas_token = self._parse_abs_connection_string(abs_stg.credentials_sas_connection_string)
+        # get_staging_files returns DuckDB az://<container>/<path> URLs; Databricks COPY INTO needs
+        # the abfss:// form.
+        abfss_files = [
+            f"abfss://{abs_stg.container}@{account_name}.dfs.core.windows.net/"
+            f"{self._abs_relative_path(f, abs_stg.container)}"
+            for f in files
+        ]
+        dirname = os.path.dirname(abfss_files[0])
+        filenames = [os.path.basename(f) for f in abfss_files]
+        quoted_filenames = [f"'{file}'" for file in filenames]
+        files_str = ", ".join(quoted_filenames)
+
+        load_query = f"""
+        COPY INTO {self.stg_name}
+        FROM '{dirname}/' WITH (
+          CREDENTIAL (AZURE_SAS_TOKEN = '{sas_token}')
         )
         FILEFORMAT = CSV
         FILES = ({files_str})
@@ -272,24 +307,88 @@ class Component(ComponentBase):
 
                 self._execute_query(merge_sql)
 
-    def get_s3_paths(self):
+    def get_staging_files(self):
+        """
+        Registers the cloud-storage secret in DuckDB and returns the list of staged CSV file URLs
+        (DuckDB-readable form) read from the Keboola input staging manifest.
+
+        Supports both S3 staging (AWS-backed stacks) and Azure Blob Storage staging (Azure-backed
+        stacks); the staging type is detected from the input table manifest at runtime.
+        """
+        if self.table.abs_staging:
+            return self._get_abs_staging_files()
+        if self.table.s3_staging:
+            return self._get_s3_staging_files()
+        raise UserException("Input table has no supported file staging (S3 or Azure Blob Storage).")
+
+    def _get_s3_staging_files(self):
+        s3 = self.table.s3_staging
         self._connection.execute(
             f"""
             CREATE OR REPLACE SECRET (
                 TYPE S3,
-                REGION '{self.table.s3_staging.region}',
-                KEY_ID '{self.table.s3_staging.credentials_access_key_id}',
-                SECRET '{self.table.s3_staging.credentials_secret_access_key}',
-                SESSION_TOKEN '{self.table.s3_staging.credentials_session_token}'
+                REGION '{s3.region}',
+                KEY_ID '{s3.credentials_access_key_id}',
+                SECRET '{s3.credentials_secret_access_key}',
+                SESSION_TOKEN '{s3.credentials_session_token}'
+            );
+            """
+        )
+        # read the manifest (list of dictionaries) and extract the table file urls
+        manifest = self._connection.sql(f"FROM read_json('s3://{s3.bucket}/{s3.key}')").fetchone()[0]
+        files = [f.get("url") for f in manifest]
+        return files
+
+    def _get_abs_staging_files(self):
+        abs_stg = self.table.abs_staging
+        # DuckDB's azure extension needs the curl transport when using a connection string secret.
+        self._connection.execute("SET azure_transport_option_type = 'curl';")
+        self._connection.execute(
+            f"""
+            CREATE OR REPLACE SECRET (
+                TYPE AZURE,
+                CONNECTION_STRING '{abs_stg.credentials_sas_connection_string}'
             );
             """
         )
         # read the manifest (list of dictionaries) and extract the table file urls
         manifest = self._connection.sql(
-            f"FROM read_json('s3://{self.table.s3_staging.bucket}/{self.table.s3_staging.key}')"
+            f"FROM read_json('az://{abs_stg.container}/{abs_stg.name}')"
         ).fetchone()[0]
-        files = [f.get("url") for f in manifest]
-        return files
+        # Normalize each slice URL to DuckDB's az://<container>/<path> form. The exact URL scheme
+        # Keboola writes into ABS slice manifests is not documented, so _abs_relative_path tolerates
+        # the variants where the container appears as a path segment (az://, azure://, https://).
+        # This path must be confirmed against a real Azure-backed stack run (see PR notes).
+        return [
+            f"az://{abs_stg.container}/{self._abs_relative_path(f.get('url'), abs_stg.container)}"
+            for f in manifest
+        ]
+
+    @staticmethod
+    def _abs_relative_path(url: str, container: str) -> str:
+        """
+        Returns the blob path relative to the container, for URL schemes where the container name
+        appears as a path segment (az://container/x, azure://acct.blob.../container/x,
+        https://acct.blob.../container/x).
+        """
+        marker = f"{container}/"
+        if marker in url:
+            return url.split(marker, 1)[1]
+        # Unknown scheme - strip a leading scheme:// if present and return the remainder.
+        return url.split("://", 1)[-1]
+
+    @staticmethod
+    def _parse_abs_connection_string(conn_str: str) -> tuple[str, str]:
+        """
+        Parses Keboola's ABS `sas_connection_string` into (account_name, sas_token).
+
+        Format: 'BlobEndpoint=https://<account>.blob.core.windows.net;SharedAccessSignature=sv=...'
+        """
+        parts = dict(part.split("=", 1) for part in conn_str.split(";") if "=" in part)
+        blob_endpoint = parts.get("BlobEndpoint", "")
+        account_name = blob_endpoint.split("://", 1)[-1].split(".", 1)[0]
+        sas_token = parts.get("SharedAccessSignature", "")
+        return account_name, sas_token
 
     def _execute_query(self, query):
         to_log = re.sub(r"CREDENTIAL\s\(.+\)", "CREDENTIAL (--SENSITIVE--)", query, flags=re.DOTALL)

--- a/src/component.py
+++ b/src/component.py
@@ -16,7 +16,7 @@ from keboola.component.exceptions import UserException
 from keboola.component.sync_actions import SelectElement
 from storage_api_client import SAPIClient
 
-from configuration import Configuration
+from configuration import Configuration, AuthType
 
 DUCK_DB_DIR = os.path.join(os.environ.get("TMPDIR", "/tmp"), "duckdb")
 
@@ -30,6 +30,19 @@ class Component(ComponentBase):
         self.table = None
         self.stg_name = None
         self.uc_table_path = None
+
+    def _get_workspace_client(self) -> WorkspaceClient:
+        """
+        Returns a Databricks WorkspaceClient authenticated either with a personal access token (PAT)
+        or with service principal (OAuth M2M) credentials, depending on the selected auth type.
+        """
+        if self.params.auth_type == AuthType.service_principal:
+            return WorkspaceClient(
+                host=self.params.unity_catalog_url,
+                client_id=self.params.unity_catalog_client_id,
+                client_secret=self.params.unity_catalog_client_secret,
+            )
+        return WorkspaceClient(host=self.params.unity_catalog_url, token=self.params.unity_catalog_token)
 
     def run(self):
         tables = self.get_input_tables_definitions(orphaned_manifests=True)
@@ -184,7 +197,7 @@ class Component(ComponentBase):
         if not self.params.destination.warehouse:
             raise UserException("Warehouse must be specified for native tables.")
 
-        self._uc_client = WorkspaceClient(host=self.params.unity_catalog_url, token=self.params.unity_catalog_token)
+        self._uc_client = self._get_workspace_client()
 
         # Create staging table
         self._execute_query(self._build_query_create_stage())
@@ -328,9 +341,7 @@ class Component(ComponentBase):
                 if not self.params.access_method == "unity_catalog":
                     raise UserException(f"Unknown provider: {self.params.provider}")
 
-                self._uc_client = WorkspaceClient(
-                    host=self.params.unity_catalog_url, token=self.params.unity_catalog_token
-                )
+                self._uc_client = self._get_workspace_client()
 
                 temp_creds, region = self._get_temp_credentials_and_region()
                 uri = temp_creds.url
@@ -385,25 +396,25 @@ class Component(ComponentBase):
 
     @sync_action("list_uc_catalogs")
     def list_uc_catalogs(self):
-        w = WorkspaceClient(host=self.params.unity_catalog_url, token=self.params.unity_catalog_token)
+        w = self._get_workspace_client()
         catalogs = w.catalogs.list()
         return [SelectElement(c.name) for c in catalogs]
 
     @sync_action("list_uc_schemas")
     def list_uc_schemas(self):
-        w = WorkspaceClient(host=self.params.unity_catalog_url, token=self.params.unity_catalog_token)
+        w = self._get_workspace_client()
         schemas = w.schemas.list(self.params.destination.catalog)
         return [SelectElement(s.name) for s in schemas]
 
     @sync_action("list_uc_tables")
     def list_uc_tables(self):
-        w = WorkspaceClient(host=self.params.unity_catalog_url, token=self.params.unity_catalog_token)
+        w = self._get_workspace_client()
         tables = w.tables.list(self.params.destination.catalog, self.params.destination.schema_name)
         return [SelectElement(t.name) for t in tables]
 
     @sync_action("list_warehouses")
     def list_dbx_warehouses(self):
-        uc_client = WorkspaceClient(host=self.params.unity_catalog_url, token=self.params.unity_catalog_token)
+        uc_client = self._get_workspace_client()
         warehouses = uc_client.warehouses.list()
         return [SelectElement(value=w.id, label=w.name) for w in warehouses]
 

--- a/src/component.py
+++ b/src/component.py
@@ -82,7 +82,7 @@ class Component(ComponentBase):
 
         relation = None
         if tables:
-            dtypes = {key: value.data_types.get("base").dtype for key, value in self.table.schema.items()}
+            dtypes = {key: self._column_base_dtype(value) for key, value in self.table.schema.items()}
             staging_files = self.get_staging_files()
 
             relation = self._connection.sql(f"""
@@ -246,7 +246,7 @@ class Component(ComponentBase):
         cast_cols_upsert = {}
 
         for idx, (col_name, col_def) in enumerate(self.table.schema.items()):
-            dtype = col_def.data_types["base"].dtype
+            dtype = self._column_base_dtype(col_def)
             col_defs.append(f"{col_name} {dtype}")
             cast_cols.append(f"CAST(_c{idx} AS {dtype}) AS {col_name}")
             cast_cols_upsert[col_name] = f"CAST(source._c{idx} AS {dtype})"  # for upsert
@@ -376,6 +376,16 @@ class Component(ComponentBase):
             return url.split(marker, 1)[1]
         # Unknown scheme - strip a leading scheme:// if present and return the remainder.
         return url.split("://", 1)[-1]
+
+    @staticmethod
+    def _column_base_dtype(col_def, default="STRING"):
+        """
+        Returns the column's base data type, falling back to STRING for non-typed input tables
+        (whose manifest schema carries no `data_type`, so `data_types` is empty). This mirrors
+        Keboola's own default of treating untyped columns as STRING.
+        """
+        base = col_def.data_types.get("base") if col_def.data_types else None
+        return base.dtype if base else default
 
     @staticmethod
     def _parse_abs_connection_string(conn_str: str) -> tuple[str, str]:

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -8,6 +8,11 @@ class AccessMethod(str, Enum):
     direct_storage = "direct_storage"
 
 
+class AuthType(str, Enum):
+    pat = "pat"
+    service_principal = "service_principal"
+
+
 class TableType(str, Enum):
     external = "external"
     native = "native"
@@ -38,7 +43,10 @@ class Destination(BaseModel):
 class Configuration(BaseModel):
     access_method: AccessMethod = Field(default=AccessMethod.direct_storage)
     unity_catalog_url: str = ""
+    auth_type: AuthType = Field(default=AuthType.pat)
     unity_catalog_token: str = Field(alias="#unity_catalog_token", default="")
+    unity_catalog_client_id: str = ""
+    unity_catalog_client_secret: str = Field(alias="#unity_catalog_client_secret", default="")
     provider: str = ""
     abs_account_name: str = ""
     abs_sas_token: str = Field(alias="#abs_sas_token", default="")

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,8 +1,11 @@
 import unittest
 import mock
 import os
+from types import SimpleNamespace as NS
 
 from freezegun import freeze_time
+
+from keboola.component.exceptions import UserException
 
 from component import Component
 from configuration import Configuration
@@ -19,6 +22,17 @@ def make_component(**param_overrides):
     comp = Component.__new__(Component)
     comp.params = Configuration(**params)
     return comp
+
+
+def mock_conn(manifest_rows):
+    """DuckDB connection stub whose read_json returns a single row holding the manifest list."""
+    conn = mock.MagicMock()
+    conn.sql.return_value.fetchone.return_value = [manifest_rows]
+    return conn
+
+
+def executed_sql(conn):
+    return " ".join(str(call.args[0]) for call in conn.execute.call_args_list)
 
 
 class TestComponent(unittest.TestCase):
@@ -52,6 +66,126 @@ class TestComponent(unittest.TestCase):
             client_id="client-id",
             client_secret="client-secret",
         )
+
+    # --- input file staging (S3 / Azure Blob) -----------------------------------------
+
+    def test_get_staging_files_s3(self):
+        comp = make_component()
+        s3 = NS(
+            region="us-east-1",
+            bucket="b",
+            key="k/manifest",
+            credentials_access_key_id="ak",
+            credentials_secret_access_key="sk",
+            credentials_session_token="st",
+        )
+        comp.table = NS(abs_staging=None, s3_staging=s3)
+        comp._connection = mock_conn([{"url": "s3://b/x/part-0.csv"}, {"url": "s3://b/x/part-1.csv"}])
+
+        files = comp.get_staging_files()
+
+        self.assertEqual(files, ["s3://b/x/part-0.csv", "s3://b/x/part-1.csv"])
+        self.assertIn("TYPE S3", executed_sql(comp._connection))
+        self.assertIn("s3://b/k/manifest", comp._connection.sql.call_args[0][0])
+
+    def test_get_staging_files_abs(self):
+        comp = make_component()
+        abs_stg = NS(
+            container="mycontainer",
+            name="627703071.csv.gzmanifest",
+            credentials_sas_connection_string=(
+                "BlobEndpoint=https://acct.blob.core.windows.net;SharedAccessSignature=sv=X&sig=Y"
+            ),
+        )
+        comp.table = NS(abs_staging=abs_stg, s3_staging=None)
+        comp._connection = mock_conn(
+            [
+                {"url": "azure://acct.blob.core.windows.net/mycontainer/path/part-0.csv"},
+                {"url": "azure://acct.blob.core.windows.net/mycontainer/path/part-1.csv"},
+            ]
+        )
+
+        files = comp.get_staging_files()
+
+        # slice URLs normalized to DuckDB az://<container>/<path> form
+        self.assertEqual(
+            files,
+            ["az://mycontainer/path/part-0.csv", "az://mycontainer/path/part-1.csv"],
+        )
+        executed = executed_sql(comp._connection)
+        self.assertIn("TYPE AZURE", executed)
+        self.assertIn("azure_transport_option_type", executed)
+        # manifest read from az://<container>/<name>
+        self.assertIn("az://mycontainer/627703071.csv.gzmanifest", comp._connection.sql.call_args[0][0])
+
+    def test_get_staging_files_none_raises(self):
+        comp = make_component()
+        comp.table = NS(abs_staging=None, s3_staging=None)
+        with self.assertRaises(UserException):
+            comp.get_staging_files()
+
+    # --- native COPY INTO stage query --------------------------------------------------
+
+    def test_build_s3_load_stage(self):
+        comp = make_component()
+        comp.stg_name = "stg_1_1"
+        s3 = NS(
+            credentials_access_key_id="ak",
+            credentials_secret_access_key="sk",
+            credentials_session_token="st",
+        )
+        comp.table = NS(abs_staging=None, s3_staging=s3)
+
+        query = comp._build_s3_load_stage(["s3://b/x/part-0.csv", "s3://b/x/part-1.csv"])
+
+        self.assertIn("AWS_ACCESS_KEY = 'ak'", query)
+        self.assertIn("FROM 's3://b/x/'", query)
+        self.assertIn("'part-0.csv'", query)
+
+    def test_build_abs_load_stage(self):
+        comp = make_component()
+        comp.stg_name = "stg_1_1"
+        abs_stg = NS(
+            container="mycontainer",
+            credentials_sas_connection_string=(
+                "BlobEndpoint=https://acct.blob.core.windows.net;SharedAccessSignature=sv=X&sig=Y"
+            ),
+        )
+        comp.table = NS(abs_staging=abs_stg, s3_staging=None)
+
+        query = comp._build_abs_load_stage(
+            ["az://mycontainer/path/part-0.csv", "az://mycontainer/path/part-1.csv"]
+        )
+
+        self.assertIn("AZURE_SAS_TOKEN = 'sv=X&sig=Y'", query)
+        self.assertIn("FROM 'abfss://mycontainer@acct.dfs.core.windows.net/path/'", query)
+        self.assertIn("'part-0.csv'", query)
+
+    # --- ABS helpers -------------------------------------------------------------------
+
+    def test_parse_abs_connection_string(self):
+        # real Keboola ABS staging connection string (URL-encoded sig, multiple SAS params)
+        conn_str = (
+            "BlobEndpoint=https://kbcfshc7chguaeh2km.blob.core.windows.net;"
+            "SharedAccessSignature=sv=2017-11-09&sr=c&st=2026-07-16T12:50:12Z&se=2026-07-17T00:50:12Z"
+            "&sp=rl&sig=Td2bBoGTGuBKDlBzng%2B2JHGzx%2BP34adli7LG%2FMg2CJY%3D"
+        )
+        account, sas = Component._parse_abs_connection_string(conn_str)
+        self.assertEqual(account, "kbcfshc7chguaeh2km")
+        self.assertEqual(
+            sas,
+            "sv=2017-11-09&sr=c&st=2026-07-16T12:50:12Z&se=2026-07-17T00:50:12Z"
+            "&sp=rl&sig=Td2bBoGTGuBKDlBzng%2B2JHGzx%2BP34adli7LG%2FMg2CJY%3D",
+        )
+
+    def test_abs_relative_path_variants(self):
+        cases = [
+            "az://cont/a/b.csv",
+            "azure://acct.blob.core.windows.net/cont/a/b.csv",
+            "https://acct.blob.core.windows.net/cont/a/b.csv",
+        ]
+        for url in cases:
+            self.assertEqual(Component._abs_relative_path(url, "cont"), "a/b.csv", msg=url)
 
 
 if __name__ == "__main__":

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,9 +1,24 @@
 import unittest
 import mock
 import os
+
 from freezegun import freeze_time
 
 from component import Component
+from configuration import Configuration
+
+
+def make_component(**param_overrides):
+    """Build a Component instance without running ComponentBase.__init__ (no datadir needed)."""
+    params = {
+        "access_method": "unity_catalog",
+        "unity_catalog_url": "https://workspace.example.com",
+        "destination": {},
+    }
+    params.update(param_overrides)
+    comp = Component.__new__(Component)
+    comp.params = Configuration(**params)
+    return comp
 
 
 class TestComponent(unittest.TestCase):
@@ -16,7 +31,28 @@ class TestComponent(unittest.TestCase):
             comp = Component()
             comp.run()
 
+    # --- auth selection ---------------------------------------------------------------
+
+    @mock.patch("component.WorkspaceClient")
+    def test_get_workspace_client_pat(self, wc):
+        comp = make_component(auth_type="pat", **{"#unity_catalog_token": "dapi-token"})
+        comp._get_workspace_client()
+        wc.assert_called_once_with(host="https://workspace.example.com", token="dapi-token")
+
+    @mock.patch("component.WorkspaceClient")
+    def test_get_workspace_client_service_principal(self, wc):
+        comp = make_component(
+            auth_type="service_principal",
+            unity_catalog_client_id="client-id",
+            **{"#unity_catalog_client_secret": "client-secret"},
+        )
+        comp._get_workspace_client()
+        wc.assert_called_once_with(
+            host="https://workspace.example.com",
+            client_id="client-id",
+            client_secret="client-secret",
+        )
+
 
 if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace as NS
 
 from freezegun import freeze_time
 
+from keboola.component.dao import ColumnDefinition
 from keboola.component.exceptions import UserException
 
 from component import Component
@@ -177,6 +178,18 @@ class TestComponent(unittest.TestCase):
             "sv=2017-11-09&sr=c&st=2026-07-16T12:50:12Z&se=2026-07-17T00:50:12Z"
             "&sp=rl&sig=Td2bBoGTGuBKDlBzng%2B2JHGzx%2BP34adli7LG%2FMg2CJY%3D",
         )
+
+    # --- base dtype resolution (typed vs non-typed input tables) -----------------------
+
+    def test_column_base_dtype_typed(self):
+        col = ColumnDefinition().from_dict({"name": "c", "data_type": {"base": {"type": "INTEGER"}}})
+        self.assertEqual(Component._column_base_dtype(col), "INTEGER")
+
+    def test_column_base_dtype_untyped_defaults_to_string(self):
+        # non-typed input table: manifest schema has no data_type -> data_types is empty
+        col = ColumnDefinition().from_dict({"name": "c", "primary_key": False})
+        self.assertEqual(col.data_types, {})
+        self.assertEqual(Component._column_base_dtype(col), "STRING")
 
     def test_abs_relative_path_variants(self):
         cases = [


### PR DESCRIPTION
## Why
The writer only supported PAT auth for Unity Catalog and could only read Keboola input tables from **S3** staging, so it couldn't run on **Azure-backed** Keboola stacks. This adds the missing pieces (mirroring the extractor's CFTL-719 work) so the writer works on Azure.

## What changed
**1. Service-principal (OAuth M2M) auth for Unity Catalog** (`7e62b3b`)
- New `AuthType` enum (`pat` | `service_principal`) + `unity_catalog_client_id` / `#unity_catalog_client_secret` fields.
- `_get_workspace_client()` helper; all `WorkspaceClient` call sites route through it. Schema exposes the auth-type selector + client id/secret.

**2. Azure Blob Storage input file staging** (`71a6860`)
- `get_s3_paths()` -> `get_staging_files()`, detecting S3 vs Azure Blob staging from the input manifest at runtime, across both write paths:
  - External (DuckDB): `TYPE AZURE` secret from the SAS connection string, manifest read from `az://<container>/<name>`.
  - Native (Databricks `COPY INTO`): `_build_abs_load_stage()` emits an `AZURE_SAS_TOKEN` clause with `abfss://` paths.
- No config/schema change - staging follows the stack storage backend.

**3. Fix non-typed input tables** (`d7be6e7`)
- Non-typed manifests carry no per-column `data_type`, so `data_types["base"]` raised errors. Added `_column_base_dtype()` falling back to `STRING` in both write paths.

Adds unit tests for auth selection, S3/ABS staging construction, and base-type resolution.

## Note
The URL scheme inside the ABS *slice* manifest is undocumented; slice URLs are normalized defensively in `_abs_relative_path` (`az://` / `azure://` / `https://`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
